### PR TITLE
記事投稿機能の実装

### DIFF
--- a/app/assets/javascripts/articles.coffee
+++ b/app/assets/javascripts/articles.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/articles.coffee
+++ b/app/assets/javascripts/articles.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the articles controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,84 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #000;
+
+  &:visited {
+    color: #666;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: #000;
+  }
+}
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding: 0 5px 7px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px -7px 0;
+    background-color: #c00;
+    color: #fff;
+  }
+
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}
+
+label {
+  display: block;
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,74 @@
+class ArticlesController < ApplicationController
+  before_action :set_article, only: [:show, :edit, :update, :destroy]
+
+  # GET /articles
+  # GET /articles.json
+  def index
+    @articles = Article.all
+  end
+
+  # GET /articles/1
+  # GET /articles/1.json
+  def show
+  end
+
+  # GET /articles/new
+  def new
+    @article = Article.new
+  end
+
+  # GET /articles/1/edit
+  def edit
+  end
+
+  # POST /articles
+  # POST /articles.json
+  def create
+    @article = Article.new(article_params)
+
+    respond_to do |format|
+      if @article.save
+        format.html { redirect_to @article, notice: 'Article was successfully created.' }
+        format.json { render :show, status: :created, location: @article }
+      else
+        format.html { render :new }
+        format.json { render json: @article.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /articles/1
+  # PATCH/PUT /articles/1.json
+  def update
+    respond_to do |format|
+      if @article.update(article_params)
+        format.html { redirect_to @article, notice: 'Article was successfully updated.' }
+        format.json { render :show, status: :ok, location: @article }
+      else
+        format.html { render :edit }
+        format.json { render json: @article.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /articles/1
+  # DELETE /articles/1.json
+  def destroy
+    @article.destroy
+    respond_to do |format|
+      format.html { redirect_to articles_url, notice: 'Article was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_article
+      @article = Article.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def article_params
+      params.require(:article).permit(:title, :author, :text)
+    end
+end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,0 +1,2 @@
+module ArticlesHelper
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,2 @@
+class Article < ApplicationRecord
+end

--- a/app/views/articles/_article.json.jbuilder
+++ b/app/views/articles/_article.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! article, :id, :title, :author, :text, :created_at, :updated_at
+json.url article_url(article, format: :json)

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: article, local: true) do |form| %>
+  <% if article.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(article.errors.count, "error") %> prohibited this article from being saved:</h2>
+
+      <ul>
+      <% article.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :author %>
+    <%= form.text_field :author %>
+  </div>
+
+  <div class="field">
+    <%= form.label :text %>
+    <%= form.text_area :text %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Article</h1>
+
+<%= render 'form', article: @article %>
+
+<%= link_to 'Show', @article %> |
+<%= link_to 'Back', articles_path %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,0 +1,31 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Articles</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Author</th>
+      <th>Text</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @articles.each do |article| %>
+      <tr>
+        <td><%= article.title %></td>
+        <td><%= article.author %></td>
+        <td><%= article.text %></td>
+        <td><%= link_to 'Show', article %></td>
+        <td><%= link_to 'Edit', edit_article_path(article) %></td>
+        <td><%= link_to 'Destroy', article, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Article', new_article_path %>

--- a/app/views/articles/index.json.jbuilder
+++ b/app/views/articles/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @articles, partial: "articles/article", as: :article

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Article</h1>
+
+<%= render 'form', article: @article %>
+
+<%= link_to 'Back', articles_path %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @article.title %>
+</p>
+
+<p>
+  <strong>Author:</strong>
+  <%= @article.author %>
+</p>
+
+<p>
+  <strong>Text:</strong>
+  <%= @article.text %>
+</p>
+
+<%= link_to 'Edit', edit_article_path(@article) %> |
+<%= link_to 'Back', articles_path %>

--- a/app/views/articles/show.json.jbuilder
+++ b/app/views/articles/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "articles/article", article: @article

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  resources :articles
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20200201070408_create_articles.rb
+++ b/db/migrate/20200201070408_create_articles.rb
@@ -1,0 +1,11 @@
+class CreateArticles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.string :author
+      t.text :text
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,23 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_02_01_070408) do
+
+  create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.string "author"
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @article = articles(:one)
+  end
+
+  test "should get index" do
+    get articles_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_article_url
+    assert_response :success
+  end
+
+  test "should create article" do
+    assert_difference('Article.count') do
+      post articles_url, params: { article: { author: @article.author, text: @article.text, title: @article.title } }
+    end
+
+    assert_redirected_to article_url(Article.last)
+  end
+
+  test "should show article" do
+    get article_url(@article)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_article_url(@article)
+    assert_response :success
+  end
+
+  test "should update article" do
+    patch article_url(@article), params: { article: { author: @article.author, text: @article.text, title: @article.title } }
+    assert_redirected_to article_url(@article)
+  end
+
+  test "should destroy article" do
+    assert_difference('Article.count', -1) do
+      delete article_url(@article)
+    end
+
+    assert_redirected_to articles_url
+  end
+end

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  author: MyString
+  text: MyText
+
+two:
+  title: MyString
+  author: MyString
+  text: MyText

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ArticleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -1,0 +1,47 @@
+require "application_system_test_case"
+
+class ArticlesTest < ApplicationSystemTestCase
+  setup do
+    @article = articles(:one)
+  end
+
+  test "visiting the index" do
+    visit articles_url
+    assert_selector "h1", text: "Articles"
+  end
+
+  test "creating a Article" do
+    visit articles_url
+    click_on "New Article"
+
+    fill_in "Author", with: @article.author
+    fill_in "Text", with: @article.text
+    fill_in "Title", with: @article.title
+    click_on "Create Article"
+
+    assert_text "Article was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Article" do
+    visit articles_url
+    click_on "Edit", match: :first
+
+    fill_in "Author", with: @article.author
+    fill_in "Text", with: @article.text
+    fill_in "Title", with: @article.title
+    click_on "Update Article"
+
+    assert_text "Article was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Article" do
+    visit articles_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Article was successfully destroyed"
+  end
+end


### PR DESCRIPTION
#What
記事投稿機能を実装する。railsのscaffoldを用いて、articleモデルを作成し、titileカラム、authorカラム、textカラムを作成した。


#Why
記事投稿機能は本アプリケーションの根幹機能であるため。